### PR TITLE
Verilator run updates, and adding back in arm-none-eabi docker image

### DIFF
--- a/.github/workflows/lint_docker.yml
+++ b/.github/workflows/lint_docker.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           hadolint ./docker/sw-dev/Dockerfile
           hadolint ./docker/sw-aarch64-linux-gnu/Dockerfile
+          hadolint ./docker/sw-arm-none-eabi/Dockerfile
           hadolint ./docker/hw-dev/Dockerfile
           hadolint ./docker/hw-backend/Dockerfile
           hadolint ./docker/docs/Dockerfile

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -86,6 +86,21 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ steps.info.outputs.image_name }}/sw-aarch64-linux-gnu
       # --------------------
+      # SW arm-none-eabi Container - relies on SW Dev container
+      - name: Build sw-arm-none-eabi container
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker/sw-arm-none-eabi
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ steps.info.outputs.image_name }}/sw-arm-none-eabi:${{ steps.info.outputs.version }}
+            ${{ env.REGISTRY }}/${{ steps.info.outputs.image_name }}/sw-arm-none-eabi:latest
+          platforms: ${{ env.PLATFORMS }}
+      - name: Inspect sw-arm-none-eabi docker image
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.info.outputs.image_name }}/sw-arm-none-eabi
+      # --------------------
       # Doc Container - relies on SW Dev container
       - name: Build docs container
         uses: docker/build-push-action@v5

--- a/External/.gitlab-ci.yml.default
+++ b/External/.gitlab-ci.yml.default
@@ -37,7 +37,7 @@ variables:
   CLANG_VER: 18
 
 default:
-  image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.3
+  image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.4
   before_script:
     # Subproject tools
     #    - apt -y install protobuf-compiler python-protobuf libprotobuf-dev

--- a/External/.gitlab-ci.yml.default
+++ b/External/.gitlab-ci.yml.default
@@ -37,7 +37,7 @@ variables:
   CLANG_VER: 18
 
 default:
-  image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.4
+  image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.5
   before_script:
     # Subproject tools
     #    - apt -y install protobuf-compiler python-protobuf libprotobuf-dev

--- a/External/bitbucket-pipelines.yml.default
+++ b/External/bitbucket-pipelines.yml.default
@@ -21,7 +21,7 @@
 # The pipelines will scan for report files:
 # See: https://support.atlassian.com/bitbucket-cloud/docs/test-reporting-in-pipelines/
 
-image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.3
+image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.4
 
 # Yaml Anchors - cannot have anchors of just lists so lots of duplicate code
 # common_env_setup: &common_env_setup

--- a/External/bitbucket-pipelines.yml.default
+++ b/External/bitbucket-pipelines.yml.default
@@ -21,7 +21,7 @@
 # The pipelines will scan for report files:
 # See: https://support.atlassian.com/bitbucket-cloud/docs/test-reporting-in-pipelines/
 
-image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.4
+image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.5
 
 # Yaml Anchors - cannot have anchors of just lists so lots of duplicate code
 # common_env_setup: &common_env_setup

--- a/External/workflows/github_test_hw.yml
+++ b/External/workflows/github_test_hw.yml
@@ -46,7 +46,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.3
+      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.4
     env:
       CMAKE_BUILD_ARGS: -DSTATIC_ANALYSIS=OFF
     steps:
@@ -73,7 +73,7 @@ jobs:
     name: ${{ matrix.name }} Build and Test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.3
+      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.4
     needs: prepare
     strategy:
       fail-fast: false
@@ -124,7 +124,7 @@ jobs:
     name: ${{ matrix.name }} Analysis
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.3
+      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.4
     needs: prepare
     strategy:
       fail-fast: false

--- a/External/workflows/github_test_hw.yml
+++ b/External/workflows/github_test_hw.yml
@@ -46,7 +46,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.4
+      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.5
     env:
       CMAKE_BUILD_ARGS: -DSTATIC_ANALYSIS=OFF
     steps:
@@ -73,7 +73,7 @@ jobs:
     name: ${{ matrix.name }} Build and Test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.4
+      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.5
     needs: prepare
     strategy:
       fail-fast: false
@@ -124,7 +124,7 @@ jobs:
     name: ${{ matrix.name }} Analysis
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.4
+      image: ghcr.io/retlek-systems-inc/rs_cmake/hw-dev:v0.4.5
     needs: prepare
     strategy:
       fail-fast: false

--- a/External/workflows/github_test_sw.yml
+++ b/External/workflows/github_test_sw.yml
@@ -48,7 +48,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.4
+      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.5
     env:
       CMAKE_BUILD_ARGS: -DSTATIC_ANALYSIS=OFF
     steps:
@@ -75,7 +75,7 @@ jobs:
     name: ${{ matrix.name }} Build and Test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.4
+      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.5
       options: --privileged # For Tsan below can remove once https://github.com/google/sanitizers/issues/1716 no longer an issue
     needs: prepare
     strategy:
@@ -164,7 +164,7 @@ jobs:
     name: ${{ matrix.name }} Analysis
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.4
+      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.5
     needs: prepare
     strategy:
       fail-fast: false

--- a/External/workflows/github_test_sw.yml
+++ b/External/workflows/github_test_sw.yml
@@ -48,7 +48,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.3
+      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.4
     env:
       CMAKE_BUILD_ARGS: -DSTATIC_ANALYSIS=OFF
     steps:
@@ -75,7 +75,7 @@ jobs:
     name: ${{ matrix.name }} Build and Test
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.3
+      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.4
       options: --privileged # For Tsan below can remove once https://github.com/google/sanitizers/issues/1716 no longer an issue
     needs: prepare
     strategy:
@@ -164,7 +164,7 @@ jobs:
     name: ${{ matrix.name }} Analysis
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.3
+      image: ghcr.io/retlek-systems-inc/rs_cmake/sw-dev:v0.4.4
     needs: prepare
     strategy:
       fail-fast: false

--- a/Modules/FindVerilogTest.cmake
+++ b/Modules/FindVerilogTest.cmake
@@ -22,7 +22,7 @@
 
 # Currently using verilator for testing.
 if (VERILOG_TEST)
-    find_package( verilator 5.006 REQUIRED )
+    find_package( verilator 5.026 REQUIRED )
 
     if (NOT verilator_FOUND)
         message(FATAL_ERROR "Verilator was not found. Either install it, or set the VERILATOR_ROOT environment variable")
@@ -175,6 +175,7 @@ macro(add_verilator_base_target)
             $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-shift-sign-overflow>
             $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-shorten-64-to-32>
             $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-sign-conversion>
+            $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-switch-default>
             $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-thread-safety-negative>
             $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-undefined-reinterpret-cast>
             $<$<COMPILE_LANG_AND_ID:CXX,Clang,GNU>:-Wno-unused-parameter>
@@ -192,6 +193,7 @@ macro(add_verilator_base_target)
             $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-implicit-int-float-conversion>
             $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-missing-prototypes>
             $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-shadow>
+            $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-sign-compare>
             $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-switch-enum>
             $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-unreachable-code>
             $<$<COMPILE_LANG_AND_ID:CXX,Clang>:-Wno-unused-macros>

--- a/docker/hw-backend/base.cmake
+++ b/docker/hw-backend/base.cmake
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0076 NEW) # full paths
 cmake_policy(SET CMP0077 NEW) # options do nothing when defined as variable.
 cmake_policy(SET CMP0144 NEW) # find_package uses <PACKAGENAME>_ROOT for search
 
-project(base-hw-deps VERSION 0.3.5 LANGUAGES C CXX)
+project(base-hw-deps VERSION 0.4.5 LANGUAGES C CXX)
 
 include(FetchContent)
 
@@ -21,7 +21,7 @@ option(VERILOG_TEST    "Support Verilog testing."   OFF)
 
 FetchContent_Declare( rs_cmake
     GIT_REPOSITORY https://github.com/Retlek-Systems-Inc/rs_cmake
-    GIT_TAG        v0.4.2
+    GIT_TAG        v0.4.5
 )
 
 FetchContent_GetProperties( rs_cmake )

--- a/docker/hw-dev/base.cmake
+++ b/docker/hw-dev/base.cmake
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0076 NEW) # full paths
 cmake_policy(SET CMP0077 NEW) # options do nothing when defined as variable.
 cmake_policy(SET CMP0144 NEW) # find_package uses <PACKAGENAME>_ROOT for search
 
-project(base-hw-deps VERSION 0.3.5 LANGUAGES C CXX)
+project(base-hw-deps VERSION 0.4.5 LANGUAGES C CXX)
 
 include(FetchContent)
 
@@ -21,7 +21,7 @@ option(VERILOG_TEST    "Support Verilog testing."   ON)
 
 FetchContent_Declare( rs_cmake
     GIT_REPOSITORY https://github.com/Retlek-Systems-Inc/rs_cmake
-    GIT_TAG        v0.4.4
+    GIT_TAG        v0.4.5
 )
 
 FetchContent_GetProperties( rs_cmake )

--- a/docker/hw-dev/base.cmake
+++ b/docker/hw-dev/base.cmake
@@ -21,7 +21,7 @@ option(VERILOG_TEST    "Support Verilog testing."   ON)
 
 FetchContent_Declare( rs_cmake
     GIT_REPOSITORY https://github.com/Retlek-Systems-Inc/rs_cmake
-    GIT_TAG        v0.4.3
+    GIT_TAG        v0.4.4
 )
 
 FetchContent_GetProperties( rs_cmake )

--- a/docker/sw-aarch64-linux-gnu/base.cmake
+++ b/docker/sw-aarch64-linux-gnu/base.cmake
@@ -20,7 +20,7 @@ cmake_dependent_option(BUILD_BENCHMARK "No Benchmark tests"         OFF "NOT CMA
 
 FetchContent_Declare( rs_cmake
     GIT_REPOSITORY https://github.com/Retlek-Systems-Inc/rs_cmake
-    GIT_TAG        v0.4.3
+    GIT_TAG        v0.4.4
 )
 
 FetchContent_GetProperties( rs_cmake )

--- a/docker/sw-aarch64-linux-gnu/base.cmake
+++ b/docker/sw-aarch64-linux-gnu/base.cmake
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0076 NEW) # full paths
 cmake_policy(SET CMP0077 NEW) # options do nothing when defined as variable.
 cmake_policy(SET CMP0144 NEW) # find_package uses <PACKAGENAME>_ROOT for search
 
-project(base-sw-aarch64-linux-gnu-deps VERSION 0.3.5 LANGUAGES C)
+project(base-sw-aarch64-linux-gnu-deps VERSION 0.4.5 LANGUAGES C)
 
 include(FetchContent)
 
@@ -20,7 +20,7 @@ cmake_dependent_option(BUILD_BENCHMARK "No Benchmark tests"         OFF "NOT CMA
 
 FetchContent_Declare( rs_cmake
     GIT_REPOSITORY https://github.com/Retlek-Systems-Inc/rs_cmake
-    GIT_TAG        v0.4.4
+    GIT_TAG        v0.4.5
 )
 
 FetchContent_GetProperties( rs_cmake )

--- a/docker/sw-arm-none-eabi/Dockerfile
+++ b/docker/sw-arm-none-eabi/Dockerfile
@@ -55,6 +55,7 @@ RUN wget --progress=dot:giga "https://developer.arm.com/-/media/Files/downloads/
     && rm -f ${ARM_NAME}.tar.xz*
 
 ENV WORK_PATH=/tmp
+ENV PATH="$PATH:/usr/local/${ARM_NAME}"
 ENV CMAKE_ENV_DEPS_PATH=${WORK_PATH}/cmake_env_deps
 ENV CMAKE_ENV_BASE_PATH=${WORK_PATH}/base
 

--- a/docker/sw-arm-none-eabi/arm-none-eabi-gcc.toolchain.cmake
+++ b/docker/sw-arm-none-eabi/arm-none-eabi-gcc.toolchain.cmake
@@ -1,4 +1,4 @@
-# @copyright 2022 Retlek Systems Inc.
+# @copyright 2022-2024 Retlek Systems Inc.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@ set(CMAKE_SYSTEM_PROCESSOR ARM)
 set(TOOLCHAIN_TRIPPLE arm-none-eabi)
 
 # Assuming toolchain installed in /usr/local - search newest first.
-set(TOOLCHAIN_LOCATION "/usr/local/arm-gnu-toolchain-12.2.mpacbti-rel1-x86_64-${TOOLCHAIN_TRIPPLE}")
+set(TOOLCHAIN_LOCATION "/usr/local/arm-gnu-toolchain-13.3.rel1-x86_64-${TOOLCHAIN_TRIPPLE}")
 set(TOOLCHAIN_PATH ${TOOLCHAIN_LOCATION} CACHE INTERNAL "Toolchain Location.")
 
 set(TOOLCHAIN_BIN_DIR ${TOOLCHAIN_PATH}/bin)

--- a/docker/sw-arm-none-eabi/base.cmake
+++ b/docker/sw-arm-none-eabi/base.cmake
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0076 NEW) # full paths
 cmake_policy(SET CMP0077 NEW) # options do nothing when defined as variable.
 cmake_policy(SET CMP0144 NEW) # find_package uses <PACKAGENAME>_ROOT for search
 
-project(base-sw-arm-none-eabi-deps VERSION 0.4.4 LANGUAGES C)
+project(base-sw-arm-none-eabi-deps VERSION 0.4.5 LANGUAGES C)
 
 include(FetchContent)
 
@@ -20,7 +20,7 @@ cmake_dependent_option(BUILD_BENCHMARK "No Benchmark tests"         OFF "NOT CMA
 
 FetchContent_Declare( rs_cmake
     GIT_REPOSITORY https://github.com/Retlek-Systems-Inc/rs_cmake
-    GIT_TAG        v0.4.4
+    GIT_TAG        v0.4.5
 )
 
 FetchContent_GetProperties( rs_cmake )

--- a/docker/sw-arm-none-eabi/base.cmake
+++ b/docker/sw-arm-none-eabi/base.cmake
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0076 NEW) # full paths
 cmake_policy(SET CMP0077 NEW) # options do nothing when defined as variable.
 cmake_policy(SET CMP0144 NEW) # find_package uses <PACKAGENAME>_ROOT for search
 
-project(base-sw-arm-none-eabi-deps VERSION 0.3.5 LANGUAGES C)
+project(base-sw-arm-none-eabi-deps VERSION 0.4.4 LANGUAGES C)
 
 include(FetchContent)
 
@@ -20,7 +20,7 @@ cmake_dependent_option(BUILD_BENCHMARK "No Benchmark tests"         OFF "NOT CMA
 
 FetchContent_Declare( rs_cmake
     GIT_REPOSITORY https://github.com/Retlek-Systems-Inc/rs_cmake
-    GIT_TAG        v0.4.3
+    GIT_TAG        v0.4.4
 )
 
 FetchContent_GetProperties( rs_cmake )

--- a/docker/sw-dev/base.cmake
+++ b/docker/sw-dev/base.cmake
@@ -20,7 +20,7 @@ option(BUILD_BENCHMARK "Benchmark libs"             ON)
 
 FetchContent_Declare( rs_cmake
     GIT_REPOSITORY https://github.com/Retlek-Systems-Inc/rs_cmake
-    GIT_TAG        v0.4.3
+    GIT_TAG        v0.4.4
 )
 
 FetchContent_GetProperties( rs_cmake )

--- a/docker/sw-dev/base.cmake
+++ b/docker/sw-dev/base.cmake
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0076 NEW) # full paths
 cmake_policy(SET CMP0077 NEW) # options do nothing when defined as variable.
 cmake_policy(SET CMP0144 NEW) # find_package uses <PACKAGENAME>_ROOT for search
 
-project(base-sw-deps VERSION 0.3.5 LANGUAGES C CXX)
+project(base-sw-deps VERSION 0.4.5 LANGUAGES C CXX)
 
 include(FetchContent)
 
@@ -20,7 +20,7 @@ option(BUILD_BENCHMARK "Benchmark libs"             ON)
 
 FetchContent_Declare( rs_cmake
     GIT_REPOSITORY https://github.com/Retlek-Systems-Inc/rs_cmake
-    GIT_TAG        v0.4.4
+    GIT_TAG        v0.4.5
 )
 
 FetchContent_GetProperties( rs_cmake )

--- a/functions/PythonLint.cmake
+++ b/functions/PythonLint.cmake
@@ -55,10 +55,16 @@ Execution of PythonLint_<target name> will result in a
 #]=======================================================================]
 
 function(PythonLint)
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
     if(NOT DEFINED Python3_EXECUTABLE)
         message(AUTHOR_WARNING "PythonLint: Python3 not defined, use `find_package(Python3 ... REQUIRED)")
         return()
     endif()
+
+    find_python_module(black REQUIRED)
+    find_python_module(isort REQUIRED)
+    find_python_module(flake8 REQUIRED)
+    find_python_module(pylint REQUIRED)
 
     include( CMakeParseArguments )
     cmake_parse_arguments(_arg

--- a/toolchain/arm-none-eabi-gcc.toolchain.cmake
+++ b/toolchain/arm-none-eabi-gcc.toolchain.cmake
@@ -26,7 +26,7 @@ set(CMAKE_SYSTEM_PROCESSOR ARM)
 set(TOOLCHAIN_TRIPPLE arm-none-eabi)
 
 # Assuming toolchain installed in /usr/local - search newest first.
-set(TOOLCHAIN_LOCATION "/usr/local/arm-gnu-toolchain-12.2.mpacbti-rel1-x86_64-${TOOLCHAIN_TRIPPLE}")
+set(TOOLCHAIN_LOCATION "/usr/local/arm-gnu-toolchain-13.3.rel1-x86_64-${TOOLCHAIN_TRIPPLE}")
 set(TOOLCHAIN_PATH ${TOOLCHAIN_LOCATION} CACHE INTERNAL "Toolchain Location.")
 
 set(TOOLCHAIN_BIN_DIR ${TOOLCHAIN_PATH}/bin)


### PR DESCRIPTION
Adding in arm-none-eabi sw docker image.
Python updates.
Verilator build and run updates with clang 18.