### PR TITLE
Update tooling3

### DIFF
--- a/External/.pre-commit-config.yaml
+++ b/External/.pre-commit-config.yaml
@@ -9,23 +9,23 @@ repos:
 # -   hooks:
 #     -   id: check-json5
 #     repo: https://gitlab.com/bmares/check-json5
-#     rev: v1.0.0
+#     rev: v1.0.1
 -   hooks:
     -   id: gitleaks
     repo: https://github.com/gitleaks/gitleaks
-    rev: v8.28.0
+    rev: v8.30.0
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py311-plus]
 -   repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
     -   id: black
         args: [--line-length, "200"]
 -   repo: https://github.com/PyCQA/isort
-    rev: 6.0.1
+    rev: 7.0.0
     hooks:
     -   id: isort
         args: [--line-length, "200"]
@@ -34,3 +34,13 @@ repos:
     hooks:
     -   id: flake8
         args: [--max-line-length=200]
+-   repo: local
+    hooks:
+    -   id: clang-format-local
+        name: clang-format (local only)
+        # 1. Skip if GITLAB_CI is set (common in GitLab runners)
+        # 2. Skip if clang-format-20 is not installed
+        entry: sh -c 'if [ -z "$GITLAB_CI" ] && command -v clang-format-20 >/dev/null; then clang-format-20 -i --style=file "$@"; fi' --
+        language: system
+        # apps/, common/, drivers/, or modules/ followed by .cpp, .h, or .hpp
+        files: ^(apps|common|drivers|modules)/.*\.(cpp|h|hpp)$

--- a/External/workflows/github_test_sw.yml
+++ b/External/workflows/github_test_sw.yml
@@ -89,8 +89,6 @@ jobs:
             preset: native-clang-asan
           - name: "Clang Thread Sanitizer"
             preset: native-clang-tsan
-          - name: "GNU Memory Sanitizer"
-            preset: native-gcc-valgrind
           - name: "Clang Undefined Behavior Sanitizer"
             preset: native-clang-ubsan
           - name: "GCC Debug"
@@ -99,6 +97,11 @@ jobs:
             preset: native-gcc-release
           - name: "GCC Coverage"
             preset: native-gcc-coverage
+          - name: "GCC Debug Valgrind"
+            memcheck: true
+            configure_preset: native-gcc
+            build_preset: native-gcc-debug
+            test_preset: native-gcc-debug-valgrind-unit-test
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v7
@@ -121,8 +124,14 @@ jobs:
             ${{ runner.os }}-${{ matrix.preset }}-CCache
       - name: Build And Test ${{ matrix.preset }}
         run: |
-          cmake --workflow --preset ${{ matrix.preset }}
-          mv ${{ env.RPT_DIR }}/junit_test_report.xml ${{ env.RPT_DIR }}/${{matrix.preset}}_junit_test_report.xml
+          if [ -n "${{ matrix.configure_preset }}" ]; then
+            cmake --preset ${{ matrix.configure_preset }}
+            cmake --build --preset ${{ matrix.build_preset }}
+            ctest --preset ${{ matrix.test_preset }} -T memcheck --output-on-failure --test-dir ${{ env.GCC_DIR }}
+          else
+            cmake --workflow --preset ${{ matrix.preset }}
+            mv ${{ env.RPT_DIR }}/junit_test_report.xml ${{ env.RPT_DIR }}/${{matrix.preset}}_junit_test_report.xml
+          fi
       # - name: Fix for Tsan mmap random bits
       #   if: ${{ matrix.preset == 'Tsan' }}
       #   run: sysctl -w vm.mmap_rnd_bits=28 # See: https://github.com/google/sanitizers/issues/1716
@@ -133,12 +142,18 @@ jobs:
           name: coverage-results
           path: ${{ env.GCC_DIR }}/code-coverage/
       - name: Publish Test Report
-        if: ${{ always() }}
+        if: ${{ always() && !matrix.memcheck }}
         uses: mikepenz/action-junit-report@v6
         with:
           report_paths: "${{ env.RPT_DIR }}/${{ matrix.preset }}_junit_test_report.xml"
           fail_on_failure: true
           require_tests: true
+      - name: Upload Valgrind Results
+        if: ${{ always() && matrix.memcheck }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: valgrind-results
+          path: ${{ env.GCC_DIR }}/Testing/
 
   analyze:
     name: ${{ matrix.name }} Analysis

--- a/Modules/CTestValgrind.cmake.in
+++ b/Modules/CTestValgrind.cmake.in
@@ -1,0 +1,35 @@
+# @copyright 2026 Retlek Systems Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#
+# CTestValgrind.cmake.in
+# Configured into the build directory by FindDefaultTest.cmake.
+# Provides Valgrind memcheck settings for ctest -T memcheck.
+# These values override DartConfiguration.tcl at ctest runtime.
+
+set(MEMORYCHECK_TYPE Valgrind)
+set(MEMORYCHECK_COMMAND "@MEMORYCHECK_COMMAND@")
+set(MEMORYCHECK_COMMAND_OPTIONS
+    "--leak-check=full \
+     --error-exitcode=1 \
+     --track-origins=yes \
+     --show-leak-kinds=all"
+)
+set(MEMORYCHECK_SUPPRESSIONS_FILE "@CMAKE_SOURCE_DIR@/valgrind.supp")

--- a/Modules/CodeCoverage.cmake
+++ b/Modules/CodeCoverage.cmake
@@ -230,8 +230,9 @@ function(SETUP_TARGET_FOR_COVERAGE_LCOV_HTML)
             # Capturing lcov counters and generating report
     COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS}
             --gcov-tool ${GCOV_PATH}
-            --directory .
             --capture
+            --rc lcov_branch_coverage=1
+            --directory ${PROJECT_BINARY_DIR}
             --output-file ${Coverage_NAME}.info
                           # add baseline counters
     COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS}

--- a/Modules/FindDefaultTest.cmake
+++ b/Modules/FindDefaultTest.cmake
@@ -41,11 +41,12 @@ if(BUILD_TEST)
             EXECUTABLE ctest
             EXECUTABLE_ARGS ${CTEST_BUILD_FLAGS}
             LCOV_ARGS
-                --strip 1
+                # --strip 1
                 --branch-coverage
                 --function-coverage
                 --ignore-errors mismatch
                 --ignore-errors unused
+                --ignore-errors inconsistent
             GENHTML_ARGS
                 --rc genhtml_branch_coverage=1
                 --demangle-cpp
@@ -87,7 +88,21 @@ if(BUILD_TEST)
     target_ignore_static_analysis(TARGET gmock_main CLANG_TIDY CPPCHECK CPPLINT IWYU)
 
 
-    enable_testing()
+    include(CTest)   # Generates DartConfiguration.tcl AND calls enable_testing()
+
+    # --- Valgrind memcheck support ---
+    find_program(MEMORYCHECK_COMMAND valgrind)
+    if(MEMORYCHECK_COMMAND)
+        message(STATUS "Valgrind found: ${MEMORYCHECK_COMMAND} - configuring memcheck")
+        configure_file(
+            "${CMAKE_CURRENT_LIST_DIR}/CTestValgrind.cmake.in"
+            "${CMAKE_BINARY_DIR}/CTestCustom.cmake"
+            @ONLY
+        )
+    else()
+        message(STATUS "Valgrind not found - memcheck preset will not be available")
+    endif()
+
     add_definitions(-DBUILD_TEST)
     
     include(ProcessorCount)

--- a/Modules/FindVerilogTest.cmake
+++ b/Modules/FindVerilogTest.cmake
@@ -359,7 +359,7 @@ macro(setup_verilog_code_coverage_target _coverageDataFiles)
               DATA_FILES
                 ${_coverageDataFiles}
               LCOV_ARGS
-                --strip 1
+                # --strip 1
                 #--rc lcov_branch_coverage=1
               GENHTML_ARGS
                 #--rc genhtml_branch_coverage=1
@@ -376,7 +376,7 @@ macro(setup_verilog_code_coverage_target _coverageDataFiles)
               DATA_FILES
                ${_coverageDataFiles}
               LCOV_ARGS
-                --strip 1
+                # --strip 1
                 #--rc lcov_branch_coverage=1
               GENHTML_ARGS
                 #--rc genhtml_branch_coverage=1

--- a/docker/hw-backend/Dockerfile
+++ b/docker/hw-backend/Dockerfile
@@ -39,11 +39,12 @@ RUN apt-get update -y \
 
 WORKDIR ${WORK_PATH}
 
-# OpenROAD separate from build if want a newer version
+# OpenROAD is behind an authentication server now.
+# Intention for this is only Exploratory synthesis - nothing more.
 # Note no OpenROAD install for 24.04 as of yet - will wait for that.
-ARG OPENROAD_DEB_VERSION=2024-12-14
-ARG OPENROAD_DEB_FILE=openroad_2.0_amd64-ubuntu22.04-${OPENROAD_DEB_VERSION}.deb
-ARG OPENROAD_DEB_URL=https://github.com/Precision-Innovations/OpenROAD/releases/download/${OPENROAD_DEB_VERSION}/${OPENROAD_DEB_FILE}
+# ARG OPENROAD_DEB_VERSION=2024-12-14
+# ARG OPENROAD_DEB_FILE=openroad_2.0_amd64-ubuntu22.04-${OPENROAD_DEB_VERSION}.deb
+# ARG OPENROAD_DEB_URL=https://github.com/Precision-Innovations/OpenROAD/releases/download/${OPENROAD_DEB_VERSION}/${OPENROAD_DEB_FILE}
 
 # Note no OpenROAD Flow Scripts install for 24.04 as of yet - will wait for that.
 # ARG ORFS_REPO=https://github.com/The-OpenROAD-Project/OpenROAD-flow-scripts
@@ -100,7 +101,7 @@ RUN wget --progress=dot:giga ${YOSYS_TGZ_URL} \
 ENV PATH="${YOSYS_INSTALL_DIR}/oss-cad-suite/bin:${PATH}"
 
 # Install OpenROAD toolchain
-RUN wget --progress=dot:giga ${OPENROAD_DEB_URL}
+# RUN wget --progress=dot:giga ${OPENROAD_DEB_URL}
 
 # Install OpenROAD Flow Scripts
 # Disabled for now since the there is no build for ubuntu 24.04 and there are issues with python version.
@@ -121,7 +122,7 @@ RUN wget --progress=dot:giga ${OPENROAD_DEB_URL}
 
 # Set environment variables based on above installation
 ENV YOSYS_CMD=${YOSYS_INSTALL_DIR}/oss-cad-suite/bin/yosys
-ENV OPENROAD_EXE=/usr/bin/openroad
+# ENV OPENROAD_EXE=/usr/bin/openroad
 
 # TODO(phelter): Debug later - bug in final_report.tcl
 # Install OpenROAD flow scripts

--- a/presets/CMakePresets-native-clang.json
+++ b/presets/CMakePresets-native-clang.json
@@ -286,7 +286,6 @@
             "name": "native-clang-msan",
             "displayName": "Sanitize Memory",
             "description": "Build and run Unit tests - Needs Debug (Native Clang)",
-            "hidden": true,
             "steps": [
                 {
                     "type": "configure",

--- a/presets/CMakePresets-native-gcc.json
+++ b/presets/CMakePresets-native-gcc.json
@@ -138,16 +138,22 @@
             "configuration": "Coverage"
         },
         {
-            "name": "native-gcc-debug-valgrind",
+            "name": "native-gcc-valgrind-debug-unit-test",
             "displayName": "Valgrind Memory Check",
             "description": "Runs tests under Valgrind memcheck (Native GCC Debug)",
             "inherits": "base-unit-test",
             "configurePreset": "native-gcc",
             "configuration": "Debug",
-            "memoryCheck": {
-                "type": "Valgrind",
-                "sanitizerOptions": "--leak-check=full --error-exitcode=1 --track-origins=yes --show-leak-kinds=all"
-            }
+            "filter": {
+                "exclude": {
+                    "name": ".*DeathTest.*"
+                }
+            },
+            "overwriteConfigurationFile": [
+                "MemoryCheckType=Valgrind",
+                "MemoryCheckCommandOptions=--leak-check=full --error-exitcode=1 --track-origins=yes --show-leak-kinds=all",
+                "MemoryCheckSuppressionFile=${sourceDir}/valgrind.supp"
+            ]
         }
     ],
     "workflowPresets": [
@@ -266,25 +272,6 @@
                 {
                     "type": "build",
                     "name": "native-gcc-coverage-report"
-                }
-            ]
-        },
-        {
-            "name": "native-gcc-valgrind",
-            "displayName": "Valgrind Memory Check",
-            "description": "Build and run tests under Valgrind (Native GCC)",
-            "steps": [
-                {
-                    "type": "configure",
-                    "name": "native-gcc"
-                },
-                {
-                    "type": "build",
-                    "name": "native-gcc-debug"
-                },
-                {
-                    "type": "test",
-                    "name": "native-gcc-debug-valgrind"
                 }
             ]
         }


### PR DESCRIPTION
Tooling updates:

- Fixing valgrind integration in with CMakePresets
- Fixing stricter LCov definitions
- Removing OpenROAD from hw_backend - only used for exploratory synthesis

Other minor updates and fixes.